### PR TITLE
Added [SecuritySafeCritical] annotations to fix console bug

### DIFF
--- a/runtime/common.cs
+++ b/runtime/common.cs
@@ -32,6 +32,7 @@ using IKVM.Runtime;
 using IKVM.Internal;
 using AssemblyClassLoader_ = IKVM.Internal.AssemblyClassLoader;
 using jlClass = java.lang.Class;
+using System.Security;
 #if !FIRST_PASS
 using NegativeArraySizeException = java.lang.NegativeArraySizeException;
 using IllegalArgumentException = java.lang.IllegalArgumentException;
@@ -149,7 +150,8 @@ namespace IKVM.NativeCode.java.lang
 			}
 			return null;
 		}
-
+		
+		[SecuritySafeCritical]
 		private static bool IsWindowsConsole(bool stdout)
 		{
 			if (Environment.OSVersion.Platform != PlatformID.Win32NT)
@@ -184,6 +186,7 @@ namespace IKVM.NativeCode.java.lang
 		[DllImport("kernel32")]
 		private static extern int GetFileType(IntPtr hFile);
 
+		[SecuritySafeCritical]
 		[DllImport("kernel32")]
 		private static extern IntPtr GetStdHandle(int nStdHandle);
 	}

--- a/runtime/openjdk/java.io.cs
+++ b/runtime/openjdk/java.io.cs
@@ -59,6 +59,7 @@ public static class Java_java_io_Console
 	private const int STD_INPUT_HANDLE = -10;
 	private const int ENABLE_ECHO_INPUT = 0x0004;
 
+	[SecuritySafeCritical]
 	[DllImport("kernel32")]
 	private static extern IntPtr GetStdHandle(int nStdHandle);
 
@@ -68,6 +69,7 @@ public static class Java_java_io_Console
 	[DllImport("kernel32")]
 	private static extern int SetConsoleMode(IntPtr hConsoleHandle, int dwMode);
 
+	[SecuritySafeCritical]
 	public static bool echo(bool on)
 	{
 #if !FIRST_PASS


### PR DESCRIPTION
When using the windows console and asking for a password, my apps failed with an error "Attempt by security transparent method '%1' to call native code through method '%2' failed. Methods must be security critical or security safe-critical to call native code."

According to MS documentation, [SecuritySafeCritical] must be added to any method requiring it.

https://docs.microsoft.com/en-us/dotnet/framework/misc/security-transparent-code-level-2